### PR TITLE
Replaced bad newlines

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
     "token" : "NzE1MDk5NTMxNTUyNzUxNjQ2.Xs4SVg.VGgJF7gG9RxmL9Xl65DO00BLp3o",
-    "prefix" : "."\n
+    "prefix" : "."
 }

--- a/main.js
+++ b/main.js
@@ -1,3 +1,3 @@
 const {token, prefix} = require("./config.json");const Discord = require("discord.js");const client = new Discord.Client();
 client.on("ready", () => {console.log(`Bot ${client.user.tag}! logged in`);});
-client.on("message", msg => { if (message.author.bot) return; if (msg.content === `${prefix}ping`) {msg.reply("Sherry is Alive! Set the command prefix with \".pre !\" Use command \"commands\" to view the current capabilities of Sherry!");}});client.login(token);\n
+client.on("message", msg => { if (message.author.bot) return; if (msg.content === `${prefix}ping`) {msg.reply("Sherry is Alive! Set the command prefix with \".pre !\" Use command \"commands\" to view the current capabilities of Sherry!");}});client.login(token);


### PR DESCRIPTION
changes \n's to visual line breaks to prevent third party tools used on the files from bugging out, and from Sherry not responding to commands that start with a prefix.